### PR TITLE
Fix error on nightly rustc

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ impl Storage {
         let cursor = collection.find(Some(query), Some(options)).unwrap();
         for result in cursor {
             if let Ok(item) = result {
-                let candidate = bson::from_bson(Bson::Document(item)).unwrap();
+                let candidate = mongodb::from_bson(Bson::Document(item)).unwrap();
                 candidates.push(candidate);
             }
         }


### PR DESCRIPTION
Looks like this crate relies on a deprecated functionality in `rustc` - `use mongodb::bson` imports a private `extern crate` item from a different crate.
This was found during ecosystem testing in https://github.com/rust-lang/rust/pull/80763.
This PR fixes the issue.